### PR TITLE
Redesign using static dispatch with enum

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -42,7 +42,7 @@ impl Weave {
 #[cfg(test)]
 mod tests {
     use super::{
-        dimenion::{Coords, CoordsData, Dimension, Processor},
+        dimenion::{Coords, CoordsData, Dimension, DimensionKind},
         distance::{Distance, EuclideanFn},
         kernel::{ExponentialFn, Kernel, TricubicFn},
         *,
@@ -56,8 +56,8 @@ mod tests {
             data: vec![vec![0_f32], vec![1_f32]],
             pred: vec![vec![0_f32]],
         });
-        let p0 = Processor::Generic;
-        let dim0 = Dimension::new(d0, k0, c0, p0);
+        let t0 = DimensionKind::Generic;
+        let dim0 = Dimension::new(d0, k0, c0, t0);
 
         // dimension 1
         let d1 = Distance::Euclidean(EuclideanFn);
@@ -66,8 +66,8 @@ mod tests {
             data: vec![vec![0_f32], vec![1_f32]],
             pred: vec![vec![0_f32]],
         });
-        let p1 = Processor::Generic;
-        let dim1 = Dimension::new(d1, k1, c1, p1);
+        let t1 = DimensionKind::Generic;
+        let dim1 = Dimension::new(d1, k1, c1, t1);
 
         let values = vec![1_f32, 1_f32];
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -5,17 +5,13 @@ pub mod kernel;
 use crate::model::dimenion::Dimension;
 
 pub struct Weave {
-    pub dimensions: Vec<Box<dyn Dimension>>,
+    pub dimensions: Vec<Dimension>,
     values: Vec<f32>,
     lens: (usize, usize),
 }
 
 impl Weave {
-    pub fn new(
-        dimensions: Vec<Box<dyn Dimension>>,
-        values: Vec<f32>,
-        lens: (usize, usize),
-    ) -> Self {
+    pub fn new(dimensions: Vec<Dimension>, values: Vec<f32>, lens: (usize, usize)) -> Self {
         Self {
             dimensions,
             values,
@@ -46,35 +42,37 @@ impl Weave {
 #[cfg(test)]
 mod tests {
     use super::{
-        dimenion::{Coords, DimensionInfo, Generic},
-        distance::Euclidean,
-        kernel::{Exponential, Tricubic},
+        dimenion::{Coords, CoordsData, Dimension, Processor},
+        distance::{Distance, EuclideanFn},
+        kernel::{ExponentialFn, Kernel, TricubicFn},
         *,
     };
 
     fn setup() -> Weave {
         // dimension 0
-        let d0 = Euclidean;
-        let k0 = Exponential::new(1.0);
-        let c0 = Coords {
+        let d0 = Distance::Euclidean(EuclideanFn);
+        let k0 = Kernel::Exponential(ExponentialFn::new(1.0));
+        let c0 = Coords::F32(CoordsData {
             data: vec![vec![0_f32], vec![1_f32]],
             pred: vec![vec![0_f32]],
-        };
-        let dim0 = Generic(DimensionInfo::new(d0, k0, c0));
+        });
+        let p0 = Processor::Generic;
+        let dim0 = Dimension::new(d0, k0, c0, p0);
 
         // dimension 1
-        let d1 = Euclidean;
-        let k1 = Tricubic::new(1.0, 0.5);
-        let c1 = Coords {
+        let d1 = Distance::Euclidean(EuclideanFn);
+        let k1 = Kernel::Tricubic(TricubicFn::new(1.0, 0.5));
+        let c1 = Coords::F32(CoordsData {
             data: vec![vec![0_f32], vec![1_f32]],
             pred: vec![vec![0_f32]],
-        };
-        let dim1 = Generic(DimensionInfo::new(d1, k1, c1));
+        });
+        let p1 = Processor::Generic;
+        let dim1 = Dimension::new(d1, k1, c1, p1);
 
         let values = vec![1_f32, 1_f32];
 
         Weave {
-            dimensions: vec![Box::new(dim0), Box::new(dim1)],
+            dimensions: vec![dim0, dim1],
             values,
             lens: (2, 1),
         }

--- a/src/model/dimenion.rs
+++ b/src/model/dimenion.rs
@@ -1,109 +1,120 @@
 use crate::model::{distance::Distance, kernel::Kernel};
-use std::{collections::HashMap, hash::Hash};
+use std::collections::HashMap;
 
-pub struct Coords<T> {
+pub struct CoordsData<T> {
     pub data: Vec<Vec<T>>,
     pub pred: Vec<Vec<T>>,
 }
 
-pub struct DimensionInfo<D, K>
-where
-    D: Distance,
-    K: Kernel<Input = D::Output>,
-{
-    pub distance: D,
-    pub kernel: K,
-    pub coords: Coords<D::Input>,
+pub enum Coords {
+    I32(CoordsData<i32>),
+    F32(CoordsData<f32>),
 }
 
-impl<D, K> DimensionInfo<D, K>
-where
-    D: Distance,
-    K: Kernel<Input = D::Output>,
-{
-    pub fn new(distance: D, kernel: K, coords: Coords<D::Input>) -> Self {
+pub enum Processor {
+    Generic,
+    Categorical,
+}
+
+pub struct Dimension {
+    pub distance: Distance,
+    pub kernel: Kernel,
+    pub coords: Coords,
+    pub processor: Processor,
+}
+
+impl Dimension {
+    pub fn new(distance: Distance, kernel: Kernel, coords: Coords, processor: Processor) -> Self {
         Self {
             distance,
             kernel,
             coords,
+            processor,
         }
     }
-}
 
-pub struct Generic<D, K>(pub DimensionInfo<D, K>)
-where
-    D: Distance,
-    K: Kernel<Input = D::Output>;
+    pub fn update_weight(&self, i: usize, weight: &mut Vec<f32>) {
+        match self {
+            Self {
+                distance: Distance::Euclidean(distance_fn),
+                kernel: Kernel::Exponential(kernel_fn),
+                coords: Coords::F32(coords),
+                processor: Processor::Generic,
+            } => {
+                let x = &coords.data[i];
+                let y_iter = coords.pred.iter();
+                for (y, w) in y_iter.zip(weight.iter_mut()) {
+                    *w *= kernel_fn.call(&distance_fn.call(x, y));
+                }
+            }
+            Self {
+                distance: Distance::Euclidean(distance_fn),
+                kernel: Kernel::Tricubic(kernel_fn),
+                coords: Coords::F32(coords),
+                processor: Processor::Generic,
+            } => {
+                let x = &coords.data[i];
+                let y_iter = coords.pred.iter();
+                for (y, w) in y_iter.zip(weight.iter_mut()) {
+                    *w *= kernel_fn.call(&distance_fn.call(x, y));
+                }
+            }
+            Self {
+                distance: Distance::Tree(distance_fn),
+                kernel: Kernel::DepthCODEm(kernel_fn),
+                coords: Coords::I32(coords),
+                processor: Processor::Generic,
+            } => {
+                let x = &coords.data[i];
+                let y_iter = coords.pred.iter();
+                for (y, w) in y_iter.zip(weight.iter_mut()) {
+                    *w *= kernel_fn.call(&distance_fn.call(x, y));
+                }
+            }
+            Self {
+                distance: Distance::Tree(distance_fn),
+                kernel: Kernel::DepthCODEm(kernel_fn),
+                coords: Coords::I32(coords),
+                processor: Processor::Categorical,
+            } => {
+                let x = &coords.data[i];
+                let y_iter = coords.pred.iter();
+                let mut norm_map = HashMap::new();
+                let distance: Vec<i32> = y_iter.map(|y| distance_fn.call(x, y)).collect();
 
-pub struct Categorical<D, K>(pub DimensionInfo<D, K>)
-where
-    D: Distance,
-    K: Kernel<Input = D::Output>,
-    D::Output: Eq + Hash + Copy;
-
-pub trait Dimension {
-    fn update_weight(&self, i: usize, weight: &mut Vec<f32>);
-}
-
-impl<D, K> Dimension for Generic<D, K>
-where
-    D: Distance,
-    K: Kernel<Input = D::Output>,
-{
-    fn update_weight(&self, i: usize, weight: &mut Vec<f32>) {
-        let info = &self.0;
-        let x = &info.coords.data[i];
-        let y_iter = info.coords.pred.iter();
-        for (y, w) in y_iter.zip(weight.iter_mut()) {
-            *w *= self.0.kernel.call(&info.distance.call(x, y));
-        }
-    }
-}
-
-impl<D, K> Dimension for Categorical<D, K>
-where
-    D: Distance,
-    K: Kernel<Input = D::Output>,
-    D::Output: Eq + Hash + Copy,
-{
-    fn update_weight(&self, i: usize, weight: &mut Vec<f32>) {
-        let info = &self.0;
-        let x = &info.coords.data[i];
-        let y_iter = info.coords.pred.iter();
-        let mut norm_map = HashMap::new();
-        let distance: Vec<D::Output> = y_iter.map(|y| info.distance.call(x, y)).collect();
-
-        for (d, w) in distance.iter().zip(weight.iter()) {
-            norm_map.entry(d).and_modify(|x| *x += w).or_insert(*w);
-        }
-        for (d, w) in distance.iter().zip(weight.iter_mut()) {
-            *w *= info.kernel.call(d) / &norm_map[d];
+                for (d, w) in distance.iter().zip(weight.iter()) {
+                    norm_map.entry(d).and_modify(|x| *x += w).or_insert(*w);
+                }
+                for (d, w) in distance.iter().zip(weight.iter_mut()) {
+                    *w *= kernel_fn.call(d) / &norm_map[d];
+                }
+            }
+            _ => panic!("cannot update weight"),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::model::{distance::Tree, kernel::DepthCODEm};
+    use crate::model::{distance::TreeFn, kernel::DepthCODEmFn};
 
-    fn info() -> DimensionInfo<Tree, DepthCODEm> {
-        let distance = Tree;
-        let kernel = DepthCODEm::new(0.5, 3);
-        let coords = Coords {
+    use super::*;
+
+    fn coords() -> Coords {
+        Coords::I32(CoordsData {
             data: vec![vec![0, 1, 2]],
             pred: vec![vec![0, 1, 2], vec![0, 1, 8], vec![0, 6, 7], vec![3, 4, 5]],
-        };
-        DimensionInfo {
-            distance,
-            kernel,
-            coords,
-        }
+        })
     }
 
     #[test]
     fn test_generic_update_weight() {
-        let dimension = Generic(info());
+        let dimension = Dimension::new(
+            Distance::Tree(TreeFn),
+            Kernel::DepthCODEm(DepthCODEmFn::new(0.5, 3)),
+            coords(),
+            Processor::Generic,
+        );
         let mut my_weight: Vec<f32> = vec![1.0; 4];
         dimension.update_weight(0, &mut my_weight);
         let ok_weight = vec![0.5, 0.25, 0.25, 0.0];
@@ -112,7 +123,12 @@ mod tests {
 
     #[test]
     fn test_categorical_update_weight() {
-        let dimension = Categorical(info());
+        let dimension = Dimension::new(
+            Distance::Tree(TreeFn),
+            Kernel::DepthCODEm(DepthCODEmFn::new(0.5, 3)),
+            coords(),
+            Processor::Categorical,
+        );
         let mut my_weight: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0];
         dimension.update_weight(0, &mut my_weight);
         let ok_weight = vec![0.5, 0.25, 0.25, 0.0];

--- a/src/model/dimenion.rs
+++ b/src/model/dimenion.rs
@@ -11,7 +11,7 @@ pub enum Coords {
     F32(CoordsData<f32>),
 }
 
-pub enum Processor {
+pub enum DimensionKind {
     Generic,
     Categorical,
 }
@@ -20,16 +20,16 @@ pub struct Dimension {
     pub distance: Distance,
     pub kernel: Kernel,
     pub coords: Coords,
-    pub processor: Processor,
+    pub kind: DimensionKind,
 }
 
 impl Dimension {
-    pub fn new(distance: Distance, kernel: Kernel, coords: Coords, processor: Processor) -> Self {
+    pub fn new(distance: Distance, kernel: Kernel, coords: Coords, kind: DimensionKind) -> Self {
         Self {
             distance,
             kernel,
             coords,
-            processor,
+            kind,
         }
     }
 
@@ -39,7 +39,7 @@ impl Dimension {
                 distance: Distance::Euclidean(distance_fn),
                 kernel: Kernel::Exponential(kernel_fn),
                 coords: Coords::F32(coords),
-                processor: Processor::Generic,
+                kind: DimensionKind::Generic,
             } => {
                 let x = &coords.data[i];
                 let y_iter = coords.pred.iter();
@@ -51,7 +51,7 @@ impl Dimension {
                 distance: Distance::Euclidean(distance_fn),
                 kernel: Kernel::Tricubic(kernel_fn),
                 coords: Coords::F32(coords),
-                processor: Processor::Generic,
+                kind: DimensionKind::Generic,
             } => {
                 let x = &coords.data[i];
                 let y_iter = coords.pred.iter();
@@ -63,7 +63,7 @@ impl Dimension {
                 distance: Distance::Tree(distance_fn),
                 kernel: Kernel::DepthCODEm(kernel_fn),
                 coords: Coords::I32(coords),
-                processor: Processor::Generic,
+                kind: DimensionKind::Generic,
             } => {
                 let x = &coords.data[i];
                 let y_iter = coords.pred.iter();
@@ -75,7 +75,7 @@ impl Dimension {
                 distance: Distance::Tree(distance_fn),
                 kernel: Kernel::DepthCODEm(kernel_fn),
                 coords: Coords::I32(coords),
-                processor: Processor::Categorical,
+                kind: DimensionKind::Categorical,
             } => {
                 let x = &coords.data[i];
                 let y_iter = coords.pred.iter();
@@ -113,7 +113,7 @@ mod tests {
             Distance::Tree(TreeFn),
             Kernel::DepthCODEm(DepthCODEmFn::new(0.5, 3)),
             coords(),
-            Processor::Generic,
+            DimensionKind::Generic,
         );
         let mut my_weight: Vec<f32> = vec![1.0; 4];
         dimension.update_weight(0, &mut my_weight);
@@ -127,7 +127,7 @@ mod tests {
             Distance::Tree(TreeFn),
             Kernel::DepthCODEm(DepthCODEmFn::new(0.5, 3)),
             coords(),
-            Processor::Categorical,
+            DimensionKind::Categorical,
         );
         let mut my_weight: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0];
         dimension.update_weight(0, &mut my_weight);

--- a/src/model/distance.rs
+++ b/src/model/distance.rs
@@ -1,31 +1,21 @@
-pub trait Distance {
-    type Input;
-    type Output;
-
-    fn call(&self, x: &Vec<Self::Input>, y: &Vec<Self::Input>) -> Self::Output;
+pub enum Distance {
+    Euclidean(EuclideanFn),
+    Tree(TreeFn),
 }
 
-pub struct Euclidean;
-
-impl Distance for Euclidean {
-    type Input = f32;
-    type Output = f32;
-
-    fn call(&self, x: &Vec<Self::Input>, y: &Vec<Self::Input>) -> Self::Output {
+pub struct EuclideanFn;
+impl EuclideanFn {
+    pub fn call(&self, x: &Vec<f32>, y: &Vec<f32>) -> f32 {
         (x[0] - y[0]).abs()
     }
 }
 
-pub struct Tree;
-
-impl Distance for Tree {
-    type Input = i32;
-    type Output = i32;
-
-    fn call(&self, x: &Vec<Self::Input>, y: &Vec<Self::Input>) -> Self::Output {
+pub struct TreeFn;
+impl TreeFn {
+    pub fn call(&self, x: &Vec<i32>, y: &Vec<i32>) -> i32 {
         let x_iter = x.iter().rev();
         let y_iter = y.iter().rev();
-        x_iter.zip(y_iter).take_while(|(xi, yi)| xi != yi).count() as Self::Output
+        x_iter.zip(y_iter).take_while(|(xi, yi)| xi != yi).count() as i32
     }
 }
 
@@ -35,7 +25,7 @@ mod tests {
 
     #[test]
     fn test_euclidean() {
-        let distance_fn = Euclidean;
+        let distance_fn = EuclideanFn;
         let x: Vec<f32> = vec![0.0];
         let y: Vec<f32> = vec![1.0];
 
@@ -46,7 +36,7 @@ mod tests {
 
     #[test]
     fn test_tree() {
-        let distance_fn = Tree;
+        let distance_fn = TreeFn;
 
         let x = vec![0, 1, 2];
         let y_vec = vec![vec![3, 4, 5], vec![0, 6, 7], vec![0, 1, 8], vec![0, 1, 2]];

--- a/src/model/kernel.rs
+++ b/src/model/kernel.rs
@@ -1,54 +1,42 @@
-pub trait Kernel {
-    type Input;
-
-    fn call(&self, d: &Self::Input) -> f32;
+pub enum Kernel {
+    Exponential(ExponentialFn),
+    Tricubic(TricubicFn),
+    DepthCODEm(DepthCODEmFn),
 }
 
-pub struct Exponential {
+pub struct ExponentialFn {
     pub radius: f32,
 }
-
-impl Exponential {
+impl ExponentialFn {
     pub fn new(radius: f32) -> Self {
         Self { radius }
     }
-}
-
-impl Kernel for Exponential {
-    type Input = f32;
-
-    fn call(&self, d: &Self::Input) -> f32 {
+    pub fn call(&self, d: &f32) -> f32 {
         (-(d / self.radius)).exp()
     }
 }
 
-pub struct Tricubic {
+pub struct TricubicFn {
     pub radius: f32,
     pub exponent: f32,
 }
-
-impl Tricubic {
+impl TricubicFn {
     pub fn new(radius: f32, exponent: f32) -> Self {
         Self { radius, exponent }
     }
-}
-
-impl Kernel for Tricubic {
-    type Input = f32;
-
-    fn call(&self, d: &Self::Input) -> f32 {
+    pub fn call(&self, d: &f32) -> f32 {
         (1.0 - (d / self.radius).powf(self.exponent)).powi(3)
     }
 }
 
-pub struct DepthCODEm {
+pub struct DepthCODEmFn {
     pub radius: f32,
     pub maxlvl: i32,
     one_minus_radius: f32,
     maxlvl_minus_one: i32,
 }
 
-impl DepthCODEm {
+impl DepthCODEmFn {
     pub fn new(radius: f32, maxlvl: i32) -> Self {
         let one_minus_radius = 1.0 - radius;
         let maxlvl_minus_one = maxlvl - 1;
@@ -59,12 +47,7 @@ impl DepthCODEm {
             maxlvl_minus_one,
         }
     }
-}
-
-impl Kernel for DepthCODEm {
-    type Input = i32;
-
-    fn call(&self, d: &Self::Input) -> f32 {
+    pub fn call(&self, d: &i32) -> f32 {
         let d = *d;
         if d >= self.maxlvl {
             0.0
@@ -82,7 +65,7 @@ mod tests {
 
     #[test]
     fn test_exponential() {
-        let kernel_fn = Exponential::new(1.0);
+        let kernel_fn = ExponentialFn::new(1.0);
 
         let my_weight = kernel_fn.call(&1.0);
         let ok_weight = (-1.0_f32).exp();
@@ -91,7 +74,7 @@ mod tests {
 
     #[test]
     fn test_tricubic() {
-        let kernel_fn = Tricubic::new(4.0, 0.5);
+        let kernel_fn = TricubicFn::new(4.0, 0.5);
 
         let my_weight = kernel_fn.call(&1.0);
         let ok_weight = 0.125_f32;
@@ -100,7 +83,7 @@ mod tests {
 
     #[test]
     fn test_depth_codem() {
-        let kenerl_fn = DepthCODEm::new(0.5, 3);
+        let kenerl_fn = DepthCODEmFn::new(0.5, 3);
         let distance = vec![0, 1, 2, 3];
 
         let my_weight: Vec<f32> = distance.iter().map(|d| kenerl_fn.call(d)).collect();


### PR DESCRIPTION
Instead of using traits to group distance, kernel, we using enum to statically dispatch the types. This needs manually match the distance, kernel, coordinate type and way to update the weight. However it does have speed and configuration simplicity advantage.