### PR TITLE
Redesign the configuration

### DIFF
--- a/example/config.toml
+++ b/example/config.toml
@@ -6,19 +6,19 @@ pred = "example/data/pred.parquet"
 values = "residual_nos_1"
 
 [[dimensions]]
-type = "Generic"
+kind = "Generic"
 key = ["age_mid"]
-distance = { type = "Euclidean" }
-kernel = { type = "Exponential", radius = 0.7 }
+distance = { kind = "Euclidean" }
+kernel = { kind = "Exponential", radius = 0.7 }
 
 [[dimensions]]
-type = "Generic"
+kind = "Generic"
 key = ["year_id"]
-distance = { type = "Euclidean" }
-kernel = { type = "Tricubic", radius = 43.0, exponent = 0.5 }
+distance = { kind = "Euclidean" }
+kernel = { kind = "Tricubic", radius = 43.0, exponent = 0.5 }
 
 [[dimensions]]
-type = "Categorical"
+kind = "Categorical"
 key = ["super_region_id", "region_id", "location_id"]
-distance = { type = "Tree" }
-kernel = { type = "DepthCODEm", radius = 0.7, maxlvl = 3 }
+distance = { kind = "Tree" }
+kernel = { kind = "DepthCODEm", radius = 0.7, maxlvl = 3 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,15 @@ use serde::Deserialize;
 use std::{error, fs, path};
 use toml;
 
-use crate::model::{dimenion::DimensionKind, distance::Distance, kernel::Kernel};
+use crate::{
+    data::{read_parquet_cols, read_parquet_nrow},
+    model::{
+        dimenion::{Coords, CoordsData, Dimension, DimensionKind},
+        distance::Distance,
+        kernel::Kernel,
+        Weave,
+    },
+};
 
 #[derive(Deserialize)]
 pub struct Config {
@@ -16,6 +24,27 @@ impl Config {
         let file = fs::read_to_string(path)?;
         let config = toml::from_str(&file)?;
         Ok(config)
+    }
+
+    pub fn into_weave(self) -> Weave {
+        let dimensions: Vec<Dimension> = self
+            .dimensions
+            .into_iter()
+            .map(|dim_config| dim_config.into_dimension(&self.datasets))
+            .collect();
+        // TODO: create read single col function
+        // TODO: the generic for path is tedious, revert to string
+        let values: Vec<f32> =
+            read_parquet_cols::<_, f32>(&self.datasets.data, &vec![self.datakeys.values])
+                .unwrap()
+                .into_iter()
+                .map(|v| v[0])
+                .collect();
+        let lens = (
+            read_parquet_nrow(&self.datasets.data).unwrap(),
+            read_parquet_nrow(&self.datasets.pred).unwrap(),
+        );
+        Weave::new(dimensions, values, lens)
     }
 }
 
@@ -36,4 +65,20 @@ pub struct DimensionConfig {
     pub key: Vec<String>,
     pub distance: Distance,
     pub kernel: Kernel,
+}
+
+impl DimensionConfig {
+    pub fn into_dimension(self, datasets: &DatasetsConfig) -> Dimension {
+        let coords = match self.distance {
+            Distance::Euclidean(_) => Coords::F32(CoordsData {
+                data: read_parquet_cols::<_, f32>(&datasets.data, &self.key).unwrap(),
+                pred: read_parquet_cols::<_, f32>(&datasets.pred, &self.key).unwrap(),
+            }),
+            Distance::Tree(_) => Coords::I32(CoordsData {
+                data: read_parquet_cols::<_, i32>(&datasets.data, &self.key).unwrap(),
+                pred: read_parquet_cols::<_, i32>(&datasets.pred, &self.key).unwrap(),
+            }),
+        };
+        Dimension::new(self.distance, self.kernel, coords, self.kind)
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,8 @@ use serde::Deserialize;
 use std::{error, fs, path};
 use toml;
 
+use crate::model::{dimenion::DimensionKind, distance::Distance, kernel::Kernel};
+
 #[derive(Deserialize)]
 pub struct Config {
     pub datasets: DatasetsConfig,
@@ -29,39 +31,9 @@ pub struct DataKeysConfig {
 }
 
 #[derive(Deserialize)]
-#[serde(tag = "type")]
-pub enum DimensionConfig {
-    Generic(DimensionInfoConfig),
-    Categorical(DimensionInfoConfig),
-}
-
-impl DimensionConfig {
-    pub fn as_inner(&self) -> &DimensionInfoConfig {
-        match self {
-            Self::Generic(info_config) => info_config,
-            Self::Categorical(info_config) => info_config,
-        }
-    }
-}
-
-#[derive(Deserialize)]
-pub struct DimensionInfoConfig {
+pub struct DimensionConfig {
+    pub kind: DimensionKind,
     pub key: Vec<String>,
-    pub distance: DistanceConfig,
-    pub kernel: KernelConfig,
-}
-
-#[derive(Deserialize)]
-#[serde(tag = "type")]
-pub enum DistanceConfig {
-    Euclidean,
-    Tree,
-}
-
-#[derive(Deserialize)]
-#[serde(tag = "type")]
-pub enum KernelConfig {
-    Exponential { radius: f32 },
-    Tricubic { radius: f32, exponent: f32 },
-    DepthCODEm { radius: f32, maxlvl: i32 },
+    pub distance: Distance,
+    pub kernel: Kernel,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,4 +18,6 @@ fn main() {
 
     let nrow = read_parquet_nrow(&config.datasets.data).unwrap();
     println!("number of rows is {}", nrow);
+
+    let _weave = config.into_weave();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,7 @@ fn main() {
     );
 
     let coord =
-        read_parquet_cols::<_, i32>(&config.datasets.data, &config.dimensions[2].as_inner().key)
-            .unwrap();
+        read_parquet_cols::<_, i32>(&config.datasets.data, &config.dimensions[2].key).unwrap();
     println!("{:?}", coord);
 
     let nrow = read_parquet_nrow(&config.datasets.data).unwrap();

--- a/src/model/dimenion.rs
+++ b/src/model/dimenion.rs
@@ -1,4 +1,5 @@
 use crate::model::{distance::Distance, kernel::Kernel};
+use serde::Deserialize;
 use std::collections::HashMap;
 
 pub struct CoordsData<T> {
@@ -11,6 +12,7 @@ pub enum Coords {
     F32(CoordsData<f32>),
 }
 
+#[derive(Deserialize)]
 pub enum DimensionKind {
     Generic,
     Categorical,

--- a/src/model/distance.rs
+++ b/src/model/distance.rs
@@ -1,8 +1,13 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(tag = "kind")]
 pub enum Distance {
     Euclidean(EuclideanFn),
     Tree(TreeFn),
 }
 
+#[derive(Deserialize)]
 pub struct EuclideanFn;
 impl EuclideanFn {
     pub fn call(&self, x: &Vec<f32>, y: &Vec<f32>) -> f32 {
@@ -10,6 +15,7 @@ impl EuclideanFn {
     }
 }
 
+#[derive(Deserialize)]
 pub struct TreeFn;
 impl TreeFn {
     pub fn call(&self, x: &Vec<i32>, y: &Vec<i32>) -> i32 {

--- a/src/model/kernel.rs
+++ b/src/model/kernel.rs
@@ -1,5 +1,5 @@
-use serde::{de, Deserialize};
-use std::fmt;
+use serde::Deserialize;
+use std::convert::From;
 
 #[derive(Deserialize)]
 #[serde(tag = "kind")]
@@ -36,6 +36,8 @@ impl TricubicFn {
     }
 }
 
+#[derive(Deserialize)]
+#[serde(from = "DepthCODEmFnNewArgs")]
 pub struct DepthCODEmFn {
     pub radius: f32,
     pub maxlvl: i32,
@@ -66,103 +68,16 @@ impl DepthCODEmFn {
     }
 }
 
-impl<'de> de::Deserialize<'de> for DepthCODEmFn {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        enum Field {
-            Radius,
-            Maxlvl,
-        }
+#[derive(Deserialize)]
+struct DepthCODEmFnNewArgs {
+    radius: f32,
+    maxlvl: i32,
+}
 
-        // This part could also be generated independently by:
-        //
-        //    #[derive(de::Deserialize)]
-        //    #[serde(field_identifier, rename_all = "lowercase")]
-        //    enum Field { Radius, Maxlvl }
-        impl<'de> de::Deserialize<'de> for Field {
-            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
-            where
-                D: de::Deserializer<'de>,
-            {
-                struct FieldVisitor;
-
-                impl<'de> de::Visitor<'de> for FieldVisitor {
-                    type Value = Field;
-
-                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                        formatter.write_str("`radius` or `maxlvl`")
-                    }
-
-                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
-                    where
-                        E: de::Error,
-                    {
-                        match value {
-                            "radius" => Ok(Field::Radius),
-                            "maxlvl" => Ok(Field::Maxlvl),
-                            _ => Err(de::Error::unknown_field(value, FIELDS)),
-                        }
-                    }
-                }
-
-                deserializer.deserialize_identifier(FieldVisitor)
-            }
-        }
-
-        struct DepthCODEmFnVisitor;
-
-        impl<'de> de::Visitor<'de> for DepthCODEmFnVisitor {
-            type Value = DepthCODEmFn;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct DepthCODEmFn")
-            }
-
-            fn visit_seq<V>(self, mut seq: V) -> Result<DepthCODEmFn, V::Error>
-            where
-                V: de::SeqAccess<'de>,
-            {
-                let radius = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                let maxlvl = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                Ok(DepthCODEmFn::new(radius, maxlvl))
-            }
-
-            fn visit_map<V>(self, mut map: V) -> Result<DepthCODEmFn, V::Error>
-            where
-                V: de::MapAccess<'de>,
-            {
-                let mut radius = None;
-                let mut maxlvl = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        Field::Radius => {
-                            if radius.is_some() {
-                                return Err(de::Error::duplicate_field("radius"));
-                            }
-                            radius = Some(map.next_value()?);
-                        }
-                        Field::Maxlvl => {
-                            if maxlvl.is_some() {
-                                return Err(de::Error::duplicate_field("maxlvl"));
-                            }
-                            maxlvl = Some(map.next_value()?);
-                        }
-                    }
-                }
-                let radius = radius.ok_or_else(|| de::Error::missing_field("radius"))?;
-                let maxlvl = maxlvl.ok_or_else(|| de::Error::missing_field("maxlvl"))?;
-                Ok(DepthCODEmFn::new(radius, maxlvl))
-            }
-        }
-
-        const FIELDS: &'static [&'static str] = &["radius", "maxlvl"];
-        deserializer.deserialize_struct("DepthCODEmFn", FIELDS, DepthCODEmFnVisitor)
+impl From<DepthCODEmFnNewArgs> for DepthCODEmFn {
+    fn from(value: DepthCODEmFnNewArgs) -> Self {
+        let DepthCODEmFnNewArgs { radius, maxlvl } = value;
+        Self::new(radius, maxlvl)
     }
 }
 


### PR DESCRIPTION
Directly use the enum for deserialize the configuration file, and complete the conversion from config struct to model struct