### PR TITLE
Restructure the model module

### DIFF
--- a/benches/small/config.toml
+++ b/benches/small/config.toml
@@ -20,6 +20,6 @@ coord = ["year_id"]
 kernel = { exponent = 0.5 }
 
 [[dimensions]]
-kind = "CategoricalHierarchical"
+kind = "CategoricalLeveled"
 coord = ["super_region_id", "region_id", "location_id"]
 kernel = { radius = 0.7 }

--- a/benches/small/config.toml
+++ b/benches/small/config.toml
@@ -20,6 +20,6 @@ coord = ["year_id"]
 kernel = { exponent = 0.5 }
 
 [[dimensions]]
-kind = "CategoricalDepthCODEm"
+kind = "CategoricalHierarchical"
 coord = ["super_region_id", "region_id", "location_id"]
 kernel = { radius = 0.7 }

--- a/benches/small/config.toml
+++ b/benches/small/config.toml
@@ -10,16 +10,16 @@ path = "benches/small/my_result.parquet"
 values = "prediction"
 
 [[dimensions]]
-kind = "Generic"
-coords = ["age_mid"]
-kernel = { kind = "Exponential", radius = 0.7 }
+kind = "GenericExponential"
+coord = ["age_mid"]
+kernel = { radius = 0.7 }
 
 [[dimensions]]
-kind = "Generic"
-coords = ["year_id"]
-kernel = { kind = "Tricubic", exponent = 0.5 }
+kind = "GenericTricubic"
+coord = ["year_id"]
+kernel = { exponent = 0.5 }
 
 [[dimensions]]
-kind = "Categorical"
-coords = ["super_region_id", "region_id", "location_id"]
-kernel = { kind = "DepthCODEm", radius = 0.7 }
+kind = "CategoricalDepthCODEm"
+coord = ["super_region_id", "region_id", "location_id"]
+kernel = { radius = 0.7 }

--- a/benches/small/config.toml
+++ b/benches/small/config.toml
@@ -12,17 +12,14 @@ values = "prediction"
 [[dimensions]]
 kind = "Generic"
 coords = ["age_mid"]
-distance = { kind = "Euclidean" }
 kernel = { kind = "Exponential", radius = 0.7 }
 
 [[dimensions]]
 kind = "Generic"
 coords = ["year_id"]
-distance = { kind = "Euclidean" }
 kernel = { kind = "Tricubic", exponent = 0.5 }
 
 [[dimensions]]
 kind = "Categorical"
 coords = ["super_region_id", "region_id", "location_id"]
-distance = { kind = "Tree" }
 kernel = { kind = "DepthCODEm", radius = 0.7 }

--- a/example/config.toml
+++ b/example/config.toml
@@ -20,6 +20,6 @@ coord = ["year_id"]
 kernel = { exponent = 0.5 }
 
 [[dimensions]]
-kind = "CategoricalHierarchical"
+kind = "CategoricalLeveled"
 coord = ["super_region_id", "region_id", "location_id"]
 kernel = { radius = 0.7 }

--- a/example/config.toml
+++ b/example/config.toml
@@ -10,19 +10,16 @@ path = "example/data/my_result.parquet"
 values = "prediction"
 
 [[dimensions]]
-kind = "Generic"
-coords = ["age_mid"]
-distance = { kind = "Euclidean" }
-kernel = { kind = "Exponential", radius = 0.7 }
+kind = "GenericExponential"
+coord = ["age_mid"]
+kernel = { radius = 0.7 }
 
 [[dimensions]]
-kind = "Generic"
-coords = ["year_id"]
-distance = { kind = "Euclidean" }
-kernel = { kind = "Tricubic", exponent = 0.5 }
+kind = "GenericTricubic"
+coord = ["year_id"]
+kernel = { exponent = 0.5 }
 
 [[dimensions]]
-kind = "Categorical"
-coords = ["super_region_id", "region_id", "location_id"]
-distance = { kind = "Tree" }
-kernel = { kind = "DepthCODEm", radius = 0.7 }
+kind = "CategoricalDepthCODEm"
+coord = ["super_region_id", "region_id", "location_id"]
+kernel = { radius = 0.7 }

--- a/example/config.toml
+++ b/example/config.toml
@@ -20,6 +20,6 @@ coord = ["year_id"]
 kernel = { exponent = 0.5 }
 
 [[dimensions]]
-kind = "CategoricalDepthCODEm"
+kind = "CategoricalHierarchical"
 coord = ["super_region_id", "region_id", "location_id"]
 kernel = { radius = 0.7 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     model::{
         dimenion::{Dimension, DimensionHandle},
-        kernel::{Exponential, Hierarchical, Tricubic},
+        kernel::{Exponential, Leveled, Tricubic},
         Weave,
     },
 };
@@ -102,12 +102,12 @@ impl TricubicBuilder {
 }
 
 #[derive(Deserialize)]
-pub struct HierarchicalBuilder {
+pub struct LeveledBuilder {
     radius: f32,
 }
-impl HierarchicalBuilder {
-    pub fn build(self, maxlvl: i32) -> Hierarchical {
-        Hierarchical::new(self.radius, maxlvl)
+impl LeveledBuilder {
+    pub fn build(self, maxlvl: i32) -> Leveled {
+        Leveled::new(self.radius, maxlvl)
     }
 }
 
@@ -122,12 +122,12 @@ pub enum DimensionBuilder {
         kernel: TricubicBuilder,
         coord: Vec<String>,
     },
-    GenericHierarchical {
-        kernel: HierarchicalBuilder,
+    GenericLeveled {
+        kernel: LeveledBuilder,
         coord: Vec<String>,
     },
-    CategoricalHierarchical {
-        kernel: HierarchicalBuilder,
+    CategoricalLeveled {
+        kernel: LeveledBuilder,
         coord: Vec<String>,
     },
     AdaptiveTricubic {
@@ -151,19 +151,17 @@ impl DimensionBuilder {
                 let kernel = kernel.build(&coord_data, &coord_pred);
                 Dimension::GenericTricubic(DimensionHandle::new(kernel, coord_data, coord_pred))
             }
-            Self::GenericHierarchical { kernel, coord } => {
+            Self::GenericLeveled { kernel, coord } => {
                 let coord_data = read_parquet_cols::<i32>(&input.data.path, &coord).unwrap();
                 let coord_pred = read_parquet_cols::<i32>(&input.pred.path, &coord).unwrap();
                 let kernel = kernel.build(coord_data.ncols as i32);
-                Dimension::GenericHierarchical(DimensionHandle::new(kernel, coord_data, coord_pred))
+                Dimension::GenericLeveled(DimensionHandle::new(kernel, coord_data, coord_pred))
             }
-            Self::CategoricalHierarchical { kernel, coord } => {
+            Self::CategoricalLeveled { kernel, coord } => {
                 let coord_data = read_parquet_cols::<i32>(&input.data.path, &coord).unwrap();
                 let coord_pred = read_parquet_cols::<i32>(&input.pred.path, &coord).unwrap();
                 let kernel = kernel.build(coord_data.ncols as i32);
-                Dimension::CategoricalHierarchical(DimensionHandle::new(
-                    kernel, coord_data, coord_pred,
-                ))
+                Dimension::CategoricalLeveled(DimensionHandle::new(kernel, coord_data, coord_pred))
             }
             Self::AdaptiveTricubic { kernel, coord } => {
                 let coord_data = read_parquet_cols::<f32>(&input.data.path, &coord).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     model::{
         dimenion::{Dimension, DimensionHandle},
-        kernel::{DepthCODEm, Exponential, Tricubic},
+        kernel::{Exponential, Hierarchical, Tricubic},
         Weave,
     },
 };
@@ -102,12 +102,12 @@ impl TricubicBuilder {
 }
 
 #[derive(Deserialize)]
-pub struct DepthCODEmBuilder {
+pub struct HierarchicalBuilder {
     radius: f32,
 }
-impl DepthCODEmBuilder {
-    pub fn build(self, maxlvl: i32) -> DepthCODEm {
-        DepthCODEm::new(self.radius, maxlvl)
+impl HierarchicalBuilder {
+    pub fn build(self, maxlvl: i32) -> Hierarchical {
+        Hierarchical::new(self.radius, maxlvl)
     }
 }
 
@@ -122,12 +122,12 @@ pub enum DimensionBuilder {
         kernel: TricubicBuilder,
         coord: Vec<String>,
     },
-    GenericDepthCODEm {
-        kernel: DepthCODEmBuilder,
+    GenericHierarchical {
+        kernel: HierarchicalBuilder,
         coord: Vec<String>,
     },
-    CategoricalDepthCODEm {
-        kernel: DepthCODEmBuilder,
+    CategoricalHierarchical {
+        kernel: HierarchicalBuilder,
         coord: Vec<String>,
     },
     AdaptiveTricubic {
@@ -151,17 +151,17 @@ impl DimensionBuilder {
                 let kernel = kernel.build(&coord_data, &coord_pred);
                 Dimension::GenericTricubic(DimensionHandle::new(kernel, coord_data, coord_pred))
             }
-            Self::GenericDepthCODEm { kernel, coord } => {
+            Self::GenericHierarchical { kernel, coord } => {
                 let coord_data = read_parquet_cols::<i32>(&input.data.path, &coord).unwrap();
                 let coord_pred = read_parquet_cols::<i32>(&input.pred.path, &coord).unwrap();
                 let kernel = kernel.build(coord_data.ncols as i32);
-                Dimension::GenericDepthCODEm(DimensionHandle::new(kernel, coord_data, coord_pred))
+                Dimension::GenericHierarchical(DimensionHandle::new(kernel, coord_data, coord_pred))
             }
-            Self::CategoricalDepthCODEm { kernel, coord } => {
+            Self::CategoricalHierarchical { kernel, coord } => {
                 let coord_data = read_parquet_cols::<i32>(&input.data.path, &coord).unwrap();
                 let coord_pred = read_parquet_cols::<i32>(&input.pred.path, &coord).unwrap();
                 let kernel = kernel.build(coord_data.ncols as i32);
-                Dimension::CategoricalDepthCODEm(DimensionHandle::new(
+                Dimension::CategoricalHierarchical(DimensionHandle::new(
                     kernel, coord_data, coord_pred,
                 ))
             }

--- a/src/model.rs
+++ b/src/model.rs
@@ -43,30 +43,26 @@ impl Weave {
 #[cfg(test)]
 mod tests {
     use super::{
-        dimenion::{Coords, CoordsData, Dimension, DimensionKind},
-        kernel::{ExponentialFn, Kernel, TricubicFn},
+        dimenion::{Dimension, DimensionHandle},
+        kernel::{Exponential, Tricubic},
         *,
     };
     use crate::data::types::Matrix;
 
     fn setup() -> Weave {
         // dimension 0
-        let k0 = Kernel::Exponential(ExponentialFn::new(1.0));
-        let c0 = Coords::F32(CoordsData {
-            data: Matrix::new(vec![0_f32, 1_f32], 1),
-            pred: Matrix::new(vec![0_f32], 1),
-        });
-        let t0 = DimensionKind::Generic;
-        let dim0 = Dimension::new(k0, c0, t0);
+        let dim0 = Dimension::GenericExponential(DimensionHandle::new(
+            Exponential::new(1.0),
+            Matrix::new(vec![0_f32, 1_f32], 1),
+            Matrix::new(vec![0_f32], 1),
+        ));
 
         // dimension 1
-        let k1 = Kernel::Tricubic(TricubicFn::new(1.0, 0.5));
-        let c1 = Coords::F32(CoordsData {
-            data: Matrix::new(vec![0_f32, 1_f32], 1),
-            pred: Matrix::new(vec![0_f32], 1),
-        });
-        let t1 = DimensionKind::Generic;
-        let dim1 = Dimension::new(k1, c1, t1);
+        let dim1 = Dimension::GenericTricubic(DimensionHandle::new(
+            Tricubic::new(1.0, 0.5),
+            Matrix::new(vec![0_f32, 1_f32], 1),
+            Matrix::new(vec![0_f32], 1),
+        ));
 
         let values = vec![1_f32, 1_f32];
         let output = Output {

--- a/src/model.rs
+++ b/src/model.rs
@@ -44,7 +44,6 @@ impl Weave {
 mod tests {
     use super::{
         dimenion::{Coords, CoordsData, Dimension, DimensionKind},
-        distance::{Distance, EuclideanFn},
         kernel::{ExponentialFn, Kernel, TricubicFn},
         *,
     };
@@ -52,24 +51,22 @@ mod tests {
 
     fn setup() -> Weave {
         // dimension 0
-        let d0 = Distance::Euclidean(EuclideanFn);
         let k0 = Kernel::Exponential(ExponentialFn::new(1.0));
         let c0 = Coords::F32(CoordsData {
             data: Matrix::new(vec![0_f32, 1_f32], 1),
             pred: Matrix::new(vec![0_f32], 1),
         });
         let t0 = DimensionKind::Generic;
-        let dim0 = Dimension::new(d0, k0, c0, t0);
+        let dim0 = Dimension::new(k0, c0, t0);
 
         // dimension 1
-        let d1 = Distance::Euclidean(EuclideanFn);
         let k1 = Kernel::Tricubic(TricubicFn::new(1.0, 0.5));
         let c1 = Coords::F32(CoordsData {
             data: Matrix::new(vec![0_f32, 1_f32], 1),
             pred: Matrix::new(vec![0_f32], 1),
         });
         let t1 = DimensionKind::Generic;
-        let dim1 = Dimension::new(d1, k1, c1, t1);
+        let dim1 = Dimension::new(k1, c1, t1);
 
         let values = vec![1_f32, 1_f32];
         let output = Output {

--- a/src/model/dimenion.rs
+++ b/src/model/dimenion.rs
@@ -1,4 +1,4 @@
-use super::kernel::{Exponential, Hierarchical, Kernel, Tricubic};
+use super::kernel::{Exponential, Kernel, Leveled, Tricubic};
 use crate::data::types::Matrix;
 
 pub trait GenericWorker {
@@ -38,7 +38,7 @@ impl<K: Kernel> GenericWorker for DimensionHandle<K> {
     }
 }
 
-impl CategoricalWorker for DimensionHandle<Hierarchical> {
+impl CategoricalWorker for DimensionHandle<Leveled> {
     fn update_weight(&self, i: usize, weight: &mut [f32]) {
         let x = self.coord_data.rows().nth(i).unwrap();
         let mut weight_sum: Vec<f32> = vec![0.0; self.kernel.maxlvl as usize + 1];
@@ -93,8 +93,8 @@ impl AdaptiveWorker for DimensionHandle<Tricubic> {
 pub enum Dimension {
     GenericExponential(DimensionHandle<Exponential>),
     GenericTricubic(DimensionHandle<Tricubic>),
-    GenericHierarchical(DimensionHandle<Hierarchical>),
-    CategoricalHierarchical(DimensionHandle<Hierarchical>),
+    GenericLeveled(DimensionHandle<Leveled>),
+    CategoricalLeveled(DimensionHandle<Leveled>),
     AdaptiveTricubic(DimensionHandle<Tricubic>),
 }
 
@@ -103,10 +103,8 @@ impl Dimension {
         match self {
             Self::GenericExponential(handle) => GenericWorker::update_weight(handle, i, weight),
             Self::GenericTricubic(handle) => GenericWorker::update_weight(handle, i, weight),
-            Self::GenericHierarchical(handle) => GenericWorker::update_weight(handle, i, weight),
-            Self::CategoricalHierarchical(handle) => {
-                CategoricalWorker::update_weight(handle, i, weight)
-            }
+            Self::GenericLeveled(handle) => GenericWorker::update_weight(handle, i, weight),
+            Self::CategoricalLeveled(handle) => CategoricalWorker::update_weight(handle, i, weight),
             Self::AdaptiveTricubic(handle) => AdaptiveWorker::update_weight(handle, i, weight),
         }
     }
@@ -119,7 +117,7 @@ mod tests {
     #[test]
     fn test_generic_update_weight() {
         let handle = DimensionHandle::new(
-            Hierarchical::new(0.5, 3),
+            Leveled::new(0.5, 3),
             Matrix::new(vec![0, 1, 2], 3),
             Matrix::new(vec![0, 1, 2, 0, 1, 8, 0, 6, 7, 3, 4, 5], 3),
         );
@@ -132,7 +130,7 @@ mod tests {
     #[test]
     fn test_categorical_update_weight() {
         let handle = DimensionHandle::new(
-            Hierarchical::new(0.5, 3),
+            Leveled::new(0.5, 3),
             Matrix::new(vec![0, 1, 2], 3),
             Matrix::new(vec![0, 1, 2, 0, 1, 8, 0, 6, 7, 3, 4, 5], 3),
         );

--- a/src/model/dimenion.rs
+++ b/src/model/dimenion.rs
@@ -1,4 +1,4 @@
-use super::kernel::{DepthCODEm, Exponential, Kernel, Tricubic};
+use super::kernel::{Exponential, Hierarchical, Kernel, Tricubic};
 use crate::data::types::Matrix;
 
 pub trait GenericWorker {
@@ -38,7 +38,7 @@ impl<K: Kernel> GenericWorker for DimensionHandle<K> {
     }
 }
 
-impl CategoricalWorker for DimensionHandle<DepthCODEm> {
+impl CategoricalWorker for DimensionHandle<Hierarchical> {
     fn update_weight(&self, i: usize, weight: &mut [f32]) {
         let x = self.coord_data.rows().nth(i).unwrap();
         let mut weight_sum: Vec<f32> = vec![0.0; self.kernel.maxlvl as usize + 1];
@@ -93,8 +93,8 @@ impl AdaptiveWorker for DimensionHandle<Tricubic> {
 pub enum Dimension {
     GenericExponential(DimensionHandle<Exponential>),
     GenericTricubic(DimensionHandle<Tricubic>),
-    GenericDepthCODEm(DimensionHandle<DepthCODEm>),
-    CategoricalDepthCODEm(DimensionHandle<DepthCODEm>),
+    GenericHierarchical(DimensionHandle<Hierarchical>),
+    CategoricalHierarchical(DimensionHandle<Hierarchical>),
     AdaptiveTricubic(DimensionHandle<Tricubic>),
 }
 
@@ -103,8 +103,8 @@ impl Dimension {
         match self {
             Self::GenericExponential(handle) => GenericWorker::update_weight(handle, i, weight),
             Self::GenericTricubic(handle) => GenericWorker::update_weight(handle, i, weight),
-            Self::GenericDepthCODEm(handle) => GenericWorker::update_weight(handle, i, weight),
-            Self::CategoricalDepthCODEm(handle) => {
+            Self::GenericHierarchical(handle) => GenericWorker::update_weight(handle, i, weight),
+            Self::CategoricalHierarchical(handle) => {
                 CategoricalWorker::update_weight(handle, i, weight)
             }
             Self::AdaptiveTricubic(handle) => AdaptiveWorker::update_weight(handle, i, weight),
@@ -119,7 +119,7 @@ mod tests {
     #[test]
     fn test_generic_update_weight() {
         let handle = DimensionHandle::new(
-            DepthCODEm::new(0.5, 3),
+            Hierarchical::new(0.5, 3),
             Matrix::new(vec![0, 1, 2], 3),
             Matrix::new(vec![0, 1, 2, 0, 1, 8, 0, 6, 7, 3, 4, 5], 3),
         );
@@ -132,7 +132,7 @@ mod tests {
     #[test]
     fn test_categorical_update_weight() {
         let handle = DimensionHandle::new(
-            DepthCODEm::new(0.5, 3),
+            Hierarchical::new(0.5, 3),
             Matrix::new(vec![0, 1, 2], 3),
             Matrix::new(vec![0, 1, 2, 0, 1, 8, 0, 6, 7, 3, 4, 5], 3),
         );

--- a/src/model/dimenion.rs
+++ b/src/model/dimenion.rs
@@ -1,158 +1,143 @@
+use super::kernel::{DepthCODEm, Exponential, Kernel, Tricubic};
 use crate::data::types::Matrix;
-use crate::model::kernel::Kernel;
-use serde::Deserialize;
 
-pub struct CoordsData<T> {
-    pub data: Matrix<T>,
-    pub pred: Matrix<T>,
+pub trait GenericWorker {
+    fn update_weight(&self, i: usize, weight: &mut [f32]);
 }
 
-pub enum Coords {
-    I32(CoordsData<i32>),
-    F32(CoordsData<f32>),
+pub trait CategoricalWorker {
+    fn update_weight(&self, i: usize, weight: &mut [f32]);
 }
 
-#[derive(Deserialize)]
-pub enum DimensionKind {
-    Generic,
-    Categorical,
-    Adaptive,
+pub trait AdaptiveWorker {
+    fn update_weight(&self, i: usize, weight: &mut [f32]);
 }
 
-pub struct Dimension {
-    pub kernel: Kernel,
-    pub coords: Coords,
-    pub kind: DimensionKind,
+pub struct DimensionHandle<K: Kernel> {
+    kernel: K,
+    coord_data: Matrix<K::CType>,
+    coord_pred: Matrix<K::CType>,
+}
+impl<K: Kernel> DimensionHandle<K> {
+    pub fn new(kernel: K, coord_data: Matrix<K::CType>, coord_pred: Matrix<K::CType>) -> Self {
+        Self {
+            kernel,
+            coord_data,
+            coord_pred,
+        }
+    }
+}
+
+impl<K: Kernel> GenericWorker for DimensionHandle<K> {
+    fn update_weight(&self, i: usize, weight: &mut [f32]) {
+        let x = self.coord_data.rows().nth(i).unwrap();
+        self.coord_pred
+            .rows()
+            .zip(weight.iter_mut())
+            .for_each(|(y, w)| *w *= self.kernel.kernel(x, y))
+    }
+}
+
+impl CategoricalWorker for DimensionHandle<DepthCODEm> {
+    fn update_weight(&self, i: usize, weight: &mut [f32]) {
+        let x = self.coord_data.rows().nth(i).unwrap();
+        let mut weight_sum: Vec<f32> = vec![0.0; self.kernel.maxlvl as usize + 1];
+
+        let distance: Vec<i32> = self
+            .coord_pred
+            .rows()
+            .zip(weight.iter())
+            .map(|(y, w)| {
+                let d = self.kernel.distance(x, y);
+                weight_sum[d as usize] += w;
+                d
+            })
+            .collect();
+
+        distance
+            .iter()
+            .zip(weight.iter_mut())
+            .map(|(d, w)| (&weight_sum[*d as usize], d, w))
+            .filter(|(s, ..)| **s > 0.0)
+            .for_each(|(s, d, w)| {
+                *w /= s;
+                *w *= self.kernel.kernel_from_distance(d);
+            });
+    }
+}
+
+impl AdaptiveWorker for DimensionHandle<Tricubic> {
+    fn update_weight(&self, i: usize, weight: &mut [f32]) {
+        let x = self.coord_data.rows().nth(i).unwrap();
+        let distance: Vec<f32> = self
+            .coord_pred
+            .rows()
+            .map(|y| self.kernel.distance(x, y))
+            .collect();
+        let radius = distance
+            .iter()
+            .max_by(|x, y| x.partial_cmp(y).unwrap())
+            .map(|x| x + 1.0)
+            .unwrap();
+        let kernel = Tricubic {
+            radius,
+            ..self.kernel
+        };
+        distance
+            .iter()
+            .zip(weight.iter_mut())
+            .for_each(|(d, w)| *w *= kernel.kernel_from_distance(d));
+    }
+}
+
+pub enum Dimension {
+    GenericExponential(DimensionHandle<Exponential>),
+    GenericTricubic(DimensionHandle<Tricubic>),
+    GenericDepthCODEm(DimensionHandle<DepthCODEm>),
+    CategoricalDepthCODEm(DimensionHandle<DepthCODEm>),
+    AdaptiveTricubic(DimensionHandle<Tricubic>),
 }
 
 impl Dimension {
-    pub fn new(kernel: Kernel, coords: Coords, kind: DimensionKind) -> Self {
-        Self {
-            kernel,
-            coords,
-            kind,
-        }
-    }
-
     pub fn update_weight(&self, i: usize, weight: &mut [f32]) {
         match self {
-            Self {
-                kernel: Kernel::Exponential(kernel_fn),
-                coords: Coords::F32(coords),
-                kind: DimensionKind::Generic,
-            } => {
-                let x = coords.data.rows().nth(i).unwrap();
-                let y_iter = coords.pred.rows();
-                for (y, w) in y_iter.zip(weight.iter_mut()) {
-                    *w *= kernel_fn.call(&kernel_fn.distance(x, y));
-                }
+            Self::GenericExponential(handle) => GenericWorker::update_weight(handle, i, weight),
+            Self::GenericTricubic(handle) => GenericWorker::update_weight(handle, i, weight),
+            Self::GenericDepthCODEm(handle) => GenericWorker::update_weight(handle, i, weight),
+            Self::CategoricalDepthCODEm(handle) => {
+                CategoricalWorker::update_weight(handle, i, weight)
             }
-            Self {
-                kernel: Kernel::Tricubic(kernel_fn),
-                coords: Coords::F32(coords),
-                kind: DimensionKind::Generic,
-            } => {
-                let x = coords.data.rows().nth(i).unwrap();
-                let y_iter = coords.pred.rows();
-                for (y, w) in y_iter.zip(weight.iter_mut()) {
-                    *w *= kernel_fn.call(&kernel_fn.distance(x, y), &kernel_fn.radius);
-                }
-            }
-            Self {
-                kernel: Kernel::DepthCODEm(kernel_fn),
-                coords: Coords::I32(coords),
-                kind: DimensionKind::Generic,
-            } => {
-                let x = coords.data.rows().nth(i).unwrap();
-                let y_iter = coords.pred.rows();
-                for (y, w) in y_iter.zip(weight.iter_mut()) {
-                    *w *= kernel_fn.call(&kernel_fn.distance(x, y));
-                }
-            }
-            Self {
-                kernel: Kernel::DepthCODEm(kernel_fn),
-                coords: Coords::I32(coords),
-                kind: DimensionKind::Categorical,
-            } => {
-                let x = coords.data.rows().nth(i).unwrap();
-                let y_iter = coords.pred.rows();
-                let mut weight_sum: Vec<f32> = vec![0.0; kernel_fn.maxlvl as usize + 1];
-                let distance: Vec<i32> = y_iter
-                    .zip(weight.iter())
-                    .map(|(y, w)| {
-                        let d = kernel_fn.distance(x, y);
-                        weight_sum[d as usize] += w;
-                        d
-                    })
-                    .collect();
-
-                distance
-                    .iter()
-                    .zip(weight.iter_mut())
-                    .map(|(d, w)| (&weight_sum[*d as usize], d, w))
-                    .filter(|(s, ..)| **s > 0.0)
-                    .for_each(|(s, d, w)| {
-                        *w /= s;
-                        *w *= kernel_fn.call(d);
-                    });
-            }
-            Self {
-                kernel: Kernel::Tricubic(kernel_fn),
-                coords: Coords::F32(coords),
-                kind: DimensionKind::Adaptive,
-            } => {
-                let x = coords.data.rows().nth(i).unwrap();
-                let y_iter = coords.pred.rows();
-                let distance: Vec<f32> = y_iter.map(|y| kernel_fn.distance(x, y)).collect();
-                let radius = distance
-                    .iter()
-                    .max_by(|x, y| x.partial_cmp(y).unwrap())
-                    .map(|x| x + 1.0)
-                    .unwrap();
-                for (d, w) in distance.iter().zip(weight.iter_mut()) {
-                    *w *= kernel_fn.call(d, &radius);
-                }
-            }
-            _ => panic!("cannot update weight"),
+            Self::AdaptiveTricubic(handle) => AdaptiveWorker::update_weight(handle, i, weight),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::model::kernel::DepthCODEmFn;
-
     use super::*;
-
-    fn coords() -> Coords {
-        Coords::I32(CoordsData {
-            data: Matrix::new(vec![0, 1, 2], 3),
-            pred: Matrix::new(vec![0, 1, 2, 0, 1, 8, 0, 6, 7, 3, 4, 5], 3),
-        })
-    }
 
     #[test]
     fn test_generic_update_weight() {
-        let dimension = Dimension::new(
-            Kernel::DepthCODEm(DepthCODEmFn::new(0.5, 3)),
-            coords(),
-            DimensionKind::Generic,
+        let handle = DimensionHandle::new(
+            DepthCODEm::new(0.5, 3),
+            Matrix::new(vec![0, 1, 2], 3),
+            Matrix::new(vec![0, 1, 2, 0, 1, 8, 0, 6, 7, 3, 4, 5], 3),
         );
         let mut my_weight: Vec<f32> = vec![1.0; 4];
-        dimension.update_weight(0, &mut my_weight);
+        GenericWorker::update_weight(&handle, 0, &mut my_weight);
         let ok_weight = vec![0.5, 0.25, 0.25, 0.0];
         assert_eq!(my_weight, ok_weight);
     }
 
     #[test]
     fn test_categorical_update_weight() {
-        let dimension = Dimension::new(
-            Kernel::DepthCODEm(DepthCODEmFn::new(0.5, 3)),
-            coords(),
-            DimensionKind::Categorical,
+        let handle = DimensionHandle::new(
+            DepthCODEm::new(0.5, 3),
+            Matrix::new(vec![0, 1, 2], 3),
+            Matrix::new(vec![0, 1, 2, 0, 1, 8, 0, 6, 7, 3, 4, 5], 3),
         );
         let mut my_weight: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0];
-        dimension.update_weight(0, &mut my_weight);
+        CategoricalWorker::update_weight(&handle, 0, &mut my_weight);
         let ok_weight = vec![0.5, 0.25, 0.25, 0.0];
         assert_eq!(my_weight, ok_weight);
     }

--- a/src/model/distance.rs
+++ b/src/model/distance.rs
@@ -4,7 +4,7 @@ pub fn euclidean(x: &[f32], y: &[f32]) -> f32 {
 }
 
 #[inline]
-pub fn tree(x: &[i32], y: &[i32]) -> i32 {
+pub fn hierarchical(x: &[i32], y: &[i32]) -> i32 {
     x.iter()
         .rev()
         .zip(y.iter().rev())
@@ -27,11 +27,11 @@ mod tests {
     }
 
     #[test]
-    fn test_tree() {
+    fn test_hierarchical() {
         let x = vec![0, 1, 2];
         let y_vec = vec![vec![3, 4, 5], vec![0, 6, 7], vec![0, 1, 8], vec![0, 1, 2]];
 
-        let my_distance: Vec<i32> = y_vec.iter().map(|y| tree(&x, y)).collect();
+        let my_distance: Vec<i32> = y_vec.iter().map(|y| hierarchical(&x, y)).collect();
         let ok_distance: Vec<i32> = vec![3, 2, 1, 0];
         assert_eq!(my_distance, ok_distance);
     }

--- a/src/model/distance.rs
+++ b/src/model/distance.rs
@@ -1,30 +1,15 @@
-use serde::Deserialize;
-
-#[derive(Deserialize)]
-#[serde(tag = "kind")]
-pub enum Distance {
-    Euclidean(EuclideanFn),
-    Tree(TreeFn),
+#[inline]
+pub fn euclidean(x: &[f32], y: &[f32]) -> f32 {
+    (x[0] - y[0]).abs()
 }
 
-#[derive(Deserialize)]
-pub struct EuclideanFn;
-impl EuclideanFn {
-    #[inline]
-    pub fn call(&self, x: &[f32], y: &[f32]) -> f32 {
-        (x[0] - y[0]).abs()
-    }
-}
-
-#[derive(Deserialize)]
-pub struct TreeFn;
-impl TreeFn {
-    #[inline]
-    pub fn call(&self, x: &[i32], y: &[i32]) -> i32 {
-        let x_iter = x.iter().rev();
-        let y_iter = y.iter().rev();
-        x_iter.zip(y_iter).take_while(|(xi, yi)| xi != yi).count() as i32
-    }
+#[inline]
+pub fn tree(x: &[i32], y: &[i32]) -> i32 {
+    x.iter()
+        .rev()
+        .zip(y.iter().rev())
+        .take_while(|(xi, yi)| xi != yi)
+        .count() as i32
 }
 
 #[cfg(test)]
@@ -33,23 +18,20 @@ mod tests {
 
     #[test]
     fn test_euclidean() {
-        let distance_fn = EuclideanFn;
         let x: Vec<f32> = vec![0.0];
         let y: Vec<f32> = vec![1.0];
 
-        let my_distance = distance_fn.call(&x, &y);
+        let my_distance = euclidean(&x, &y);
         let ok_distance = 1.0_f32;
         assert_eq!(my_distance, ok_distance);
     }
 
     #[test]
     fn test_tree() {
-        let distance_fn = TreeFn;
-
         let x = vec![0, 1, 2];
         let y_vec = vec![vec![3, 4, 5], vec![0, 6, 7], vec![0, 1, 8], vec![0, 1, 2]];
 
-        let my_distance: Vec<i32> = y_vec.iter().map(|y| distance_fn.call(&x, y)).collect();
+        let my_distance: Vec<i32> = y_vec.iter().map(|y| tree(&x, y)).collect();
         let ok_distance: Vec<i32> = vec![3, 2, 1, 0];
         assert_eq!(my_distance, ok_distance);
     }

--- a/src/model/kernel.rs
+++ b/src/model/kernel.rs
@@ -59,14 +59,14 @@ impl Kernel for Tricubic {
     }
 }
 
-pub struct DepthCODEm {
+pub struct Hierarchical {
     pub radius: f32,
     pub maxlvl: i32,
     one_minus_radius: f32,
     maxlvl_minus_one: i32,
 }
 
-impl DepthCODEm {
+impl Hierarchical {
     pub fn new(radius: f32, maxlvl: i32) -> Self {
         let one_minus_radius = 1.0 - radius;
         let maxlvl_minus_one = maxlvl - 1;
@@ -78,7 +78,7 @@ impl DepthCODEm {
         }
     }
 }
-impl Kernel for DepthCODEm {
+impl Kernel for Hierarchical {
     type CType = i32;
     type DType = i32;
 
@@ -125,7 +125,7 @@ mod tests {
 
     #[test]
     fn test_depth_codem() {
-        let kenerl = DepthCODEm::new(0.5, 3);
+        let kenerl = Hierarchical::new(0.5, 3);
         let distance = vec![0, 1, 2, 3];
 
         let my_weight: Vec<f32> = distance

--- a/src/model/kernel.rs
+++ b/src/model/kernel.rs
@@ -1,3 +1,4 @@
+use crate::model::distance::{euclidean, tree};
 use serde::Deserialize;
 
 pub enum Kernel {
@@ -15,6 +16,10 @@ impl ExponentialFn {
         Self { radius }
     }
     #[inline]
+    pub fn distance(&self, x: &[f32], y: &[f32]) -> f32 {
+        euclidean(x, y)
+    }
+    #[inline]
     pub fn call(&self, d: &f32) -> f32 {
         (-(d / self.radius)).exp()
     }
@@ -27,6 +32,10 @@ pub struct TricubicFn {
 impl TricubicFn {
     pub fn new(radius: f32, exponent: f32) -> Self {
         Self { radius, exponent }
+    }
+    #[inline]
+    pub fn distance(&self, x: &[f32], y: &[f32]) -> f32 {
+        euclidean(x, y)
     }
     #[inline]
     pub fn call(&self, d: &f32, radius: &f32) -> f32 {
@@ -52,6 +61,10 @@ impl DepthCODEmFn {
             one_minus_radius,
             maxlvl_minus_one,
         }
+    }
+    #[inline]
+    pub fn distance(&self, x: &[i32], y: &[i32]) -> i32 {
+        tree(x, y)
     }
     #[inline]
     pub fn call(&self, d: &i32) -> f32 {

--- a/src/model/kernel.rs
+++ b/src/model/kernel.rs
@@ -1,4 +1,4 @@
-use crate::model::distance::{euclidean, tree};
+use crate::model::distance::{euclidean, hierarchical};
 
 pub trait Kernel {
     type CType;
@@ -59,14 +59,14 @@ impl Kernel for Tricubic {
     }
 }
 
-pub struct Hierarchical {
+pub struct Leveled {
     pub radius: f32,
     pub maxlvl: i32,
     one_minus_radius: f32,
     maxlvl_minus_one: i32,
 }
 
-impl Hierarchical {
+impl Leveled {
     pub fn new(radius: f32, maxlvl: i32) -> Self {
         let one_minus_radius = 1.0 - radius;
         let maxlvl_minus_one = maxlvl - 1;
@@ -78,13 +78,13 @@ impl Hierarchical {
         }
     }
 }
-impl Kernel for Hierarchical {
+impl Kernel for Leveled {
     type CType = i32;
     type DType = i32;
 
     #[inline]
     fn distance(&self, x: &[Self::CType], y: &[Self::CType]) -> Self::DType {
-        tree(x, y)
+        hierarchical(x, y)
     }
 
     #[inline]
@@ -125,7 +125,7 @@ mod tests {
 
     #[test]
     fn test_depth_codem() {
-        let kenerl = Hierarchical::new(0.5, 3);
+        let kenerl = Leveled::new(0.5, 3);
         let distance = vec![0, 1, 2, 3];
 
         let my_weight: Vec<f32> = distance

--- a/src/model/kernel.rs
+++ b/src/model/kernel.rs
@@ -1,57 +1,72 @@
 use crate::model::distance::{euclidean, tree};
-use serde::Deserialize;
 
-pub enum Kernel {
-    Exponential(ExponentialFn),
-    Tricubic(TricubicFn),
-    DepthCODEm(DepthCODEmFn),
+pub trait Kernel {
+    type CType;
+    type DType;
+
+    fn distance(&self, x: &[Self::CType], y: &[Self::CType]) -> Self::DType;
+    fn kernel_from_distance(&self, d: &Self::DType) -> f32;
+    fn kernel(&self, x: &[Self::CType], y: &[Self::CType]) -> f32 {
+        self.kernel_from_distance(&self.distance(x, y))
+    }
 }
 
-#[derive(Deserialize)]
-pub struct ExponentialFn {
+pub struct Exponential {
     pub radius: f32,
 }
-impl ExponentialFn {
+impl Exponential {
     pub fn new(radius: f32) -> Self {
         Self { radius }
     }
+}
+impl Kernel for Exponential {
+    type CType = f32;
+    type DType = f32;
+
     #[inline]
-    pub fn distance(&self, x: &[f32], y: &[f32]) -> f32 {
+    fn distance(&self, x: &[Self::CType], y: &[Self::CType]) -> Self::DType {
         euclidean(x, y)
     }
+
     #[inline]
-    pub fn call(&self, d: &f32) -> f32 {
+    fn kernel_from_distance(&self, d: &Self::DType) -> f32 {
         (-(d / self.radius)).exp()
     }
 }
 
-pub struct TricubicFn {
+pub struct Tricubic {
     pub radius: f32,
     pub exponent: f32,
 }
-impl TricubicFn {
+impl Tricubic {
     pub fn new(radius: f32, exponent: f32) -> Self {
         Self { radius, exponent }
     }
+}
+impl Kernel for Tricubic {
+    type CType = f32;
+    type DType = f32;
+
     #[inline]
-    pub fn distance(&self, x: &[f32], y: &[f32]) -> f32 {
+    fn distance(&self, x: &[Self::CType], y: &[Self::CType]) -> Self::DType {
         euclidean(x, y)
     }
+
     #[inline]
-    pub fn call(&self, d: &f32, radius: &f32) -> f32 {
-        let x = 1.0 - (d / radius).powf(self.exponent);
+    fn kernel_from_distance(&self, d: &Self::DType) -> f32 {
+        let x = 1.0 - (d / self.radius).powf(self.exponent);
         x * x * x
     }
 }
 
-pub struct DepthCODEmFn {
+pub struct DepthCODEm {
     pub radius: f32,
     pub maxlvl: i32,
     one_minus_radius: f32,
     maxlvl_minus_one: i32,
 }
 
-impl DepthCODEmFn {
+impl DepthCODEm {
     pub fn new(radius: f32, maxlvl: i32) -> Self {
         let one_minus_radius = 1.0 - radius;
         let maxlvl_minus_one = maxlvl - 1;
@@ -62,12 +77,18 @@ impl DepthCODEmFn {
             maxlvl_minus_one,
         }
     }
+}
+impl Kernel for DepthCODEm {
+    type CType = i32;
+    type DType = i32;
+
     #[inline]
-    pub fn distance(&self, x: &[i32], y: &[i32]) -> i32 {
+    fn distance(&self, x: &[Self::CType], y: &[Self::CType]) -> Self::DType {
         tree(x, y)
     }
+
     #[inline]
-    pub fn call(&self, d: &i32) -> f32 {
+    fn kernel_from_distance(&self, d: &Self::DType) -> f32 {
         if d >= &self.maxlvl {
             0.0
         } else {
@@ -86,28 +107,31 @@ mod tests {
 
     #[test]
     fn test_exponential() {
-        let kernel_fn = ExponentialFn::new(1.0);
+        let kernel = Exponential::new(1.0);
 
-        let my_weight = kernel_fn.call(&1.0);
+        let my_weight = kernel.kernel_from_distance(&1.0);
         let ok_weight = (-1.0_f32).exp();
         assert_eq!(my_weight, ok_weight);
     }
 
     #[test]
     fn test_tricubic() {
-        let kernel_fn = TricubicFn::new(4.0, 0.5);
+        let kernel = Tricubic::new(4.0, 0.5);
 
-        let my_weight = kernel_fn.call(&1.0, &kernel_fn.radius);
+        let my_weight = kernel.kernel_from_distance(&1.0);
         let ok_weight = 0.125_f32;
         assert_eq!(my_weight, ok_weight);
     }
 
     #[test]
     fn test_depth_codem() {
-        let kenerl_fn = DepthCODEmFn::new(0.5, 3);
+        let kenerl = DepthCODEm::new(0.5, 3);
         let distance = vec![0, 1, 2, 3];
 
-        let my_weight: Vec<f32> = distance.iter().map(|d| kenerl_fn.call(d)).collect();
+        let my_weight: Vec<f32> = distance
+            .iter()
+            .map(|d| kenerl.kernel_from_distance(d))
+            .collect();
         let ok_weight: Vec<f32> = vec![0.5, 0.25, 0.25, 0.0];
         assert_eq!(my_weight, ok_weight);
     }


### PR DESCRIPTION
* Remove distance struct, directly use function and hard-code Kernel with its distance to reduce complexity
* Define kernels by trait rather enum to be more idiomatic
* Define dimension handle by generic, and implement traits for different behaviors on updating weights
* Use an enum to group all possibilities of dimension handle and the updating weight behavior
* Adjust the configuration correspondingly